### PR TITLE
Fixed unexpected indentation

### DIFF
--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -16,16 +16,20 @@ Color Names
 
 The ImageColor module supports the following string formats:
 
-* Hexadecimal color specifiers, given as ``#rgb``, ``#rgba``, ``#rrggbb`` or ``#rrggbbaa``, 
-  with the following placeholders: 
-    - ``r``: red
-    - ``g``: green
-    - ``b``: blue
-    - ``a``: alpha / opacity (can be used in combination with ``mode="RGBA"`` in :py:mod:`~PIL.ImageDraw`)
-  
+* Hexadecimal color specifiers, given as ``#rgb``, ``#rgba``, ``#rrggbb`` or
+  ``#rrggbbaa``, with the following placeholders:
+
+    - ``r`` red
+    - ``g`` green
+    - ``b`` blue
+    - ``a`` alpha / opacity (can be used in combination with ``mode="RGBA"`` in
+      :py:mod:`~PIL.ImageDraw`)
+
   Examples:
-   - ``#ff0000`` specifies pure red.
-   - ``#ff0000aa`` specifies pure red with an opacity of 66.66% (aa = 170, opacity = 170/255).
+
+    - ``#ff0000`` specifies pure red.
+    - ``#ff0000aa`` specifies pure red with an opacity of 66.66% (aa = 170, opacity =
+      170/255).
 
 
 * RGB functions, given as ``rgb(red, green, blue)`` where the color values are


### PR DESCRIPTION
One of the tests in https://github.com/python-pillow/Pillow/pull/5181 is [failing](https://github.com/python-pillow/Pillow/pull/5181/checks?check_run_id=1643776577#step:13:147)
> /home/runner/work/Pillow/Pillow/docs/reference/ImageColor.rst:21: WARNING: Unexpected indentation.

This PR fixes that. https://pillow-radarhere.readthedocs.io/en/m-patch-1/reference/ImageColor.html