### PR TITLE
Changes

### DIFF
--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -22,8 +22,7 @@ The ImageColor module supports the following string formats:
     - ``r`` red
     - ``g`` green
     - ``b`` blue
-    - ``a`` alpha / opacity (can be used in combination with ``mode="RGBA"`` in
-      :py:mod:`~PIL.ImageDraw`)
+    - ``a`` alpha / opacity
 
   Examples:
 

--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -28,8 +28,8 @@ The ImageColor module supports the following string formats:
   Examples:
 
     - ``#ff0000`` specifies pure red.
-    - ``#ff0000aa`` specifies pure red with an opacity of 66.66% (aa = 170, opacity =
-      170/255).
+    - ``#ff0000cc`` specifies pure red with an opacity of 80% (cc = 204, opacity =
+      204/255).
 
 
 * RGB functions, given as ``rgb(red, green, blue)`` where the color values are

--- a/docs/reference/ImageColor.rst
+++ b/docs/reference/ImageColor.rst
@@ -17,19 +17,10 @@ Color Names
 The ImageColor module supports the following string formats:
 
 * Hexadecimal color specifiers, given as ``#rgb``, ``#rgba``, ``#rrggbb`` or
-  ``#rrggbbaa``, with the following placeholders:
-
-    - ``r`` red
-    - ``g`` green
-    - ``b`` blue
-    - ``a`` alpha / opacity
-
-  Examples:
-
-    - ``#ff0000`` specifies pure red.
-    - ``#ff0000cc`` specifies pure red with an opacity of 80% (cc = 204, opacity =
-      204/255).
-
+  ``#rrggbbaa``, where ``r`` is red, ``g`` is green, ``b`` is blue and ``a`` is
+  alpha (also called 'opacity'). For example, ``#ff0000`` specifies pure red,
+  and ``#ff0000cc`` specifies red with 80% opacity (``cc`` is 204 in decimal
+  form, and 204 / 255 = 0.8).
 
 * RGB functions, given as ``rgb(red, green, blue)`` where the color values are
   integers in the range 0 to 255. Alternatively, the color values can be given


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5181. These are just my personal inclinations, so feel free to decline if you disagree.

- Changed #ff0000aa to #ff0000cc to avoid using "a" - When you mention previously that 'a' is for 'alpha', and then use 'a' here to represent 10 in hex form... I think that's slightly confusing. Maybe this is just me?
- I don't understand 'can be used in combination with ``mode="RGBA"`` in ImageDraw'. I find this vague - which method in ImageDraw? - but also, it could be used with other modules. I could do `Image.new(mode="RGBA", size=(100, 100), color=(0, 0, 0, 127))`. So I've removed that comment.
- Adjusted the formatting to be more similar to the other paragraphs.

See https://pillow-radarhere.readthedocs.io/en/alpha/reference/ImageColor.html for how my changes look.